### PR TITLE
Improvement to not force services to host websites in a subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ Hydra-router is able to route site requests to microservices. So a microservice 
 
 The benefits of using this feature is that you may launch services on dynamic ports on arbitrary IP's and leverage the router to find individual service instances. In this way, website requests can be handled by multiple load balanced service instances.
 
-In order for this feature to work a service must serve its web content from a sub-folder which contains the same name as the service. So for a service called `instructor-service` there must be a `public/instructor-service` folder which hosts the sites static files.
-
 ## HTTP proxy passthrough
 Hydra-router allows you to specify routes to non-hydra services. Essentially this allows external clients to make API requests through hydra to backend servers.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-hydra-router",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "description": "A service which routes requests to hydra-based microservices",
   "author": {
     "name": "Carlos Justiniano",

--- a/servicerouter.js
+++ b/servicerouter.js
@@ -138,7 +138,6 @@ class ServiceRouter {
       let requestUrl = request.url;
       let urlData = url.parse(`http://${request.headers['host']}${requestUrl}`);
       let matchResult = this._matchRoute(urlData);
-
       if (!matchResult) {
         if (request.headers['referer']) {
           Object.keys(this.serviceNames).forEach((serviceName) => {
@@ -146,7 +145,6 @@ class ServiceRouter {
               matchResult = {
                 serviceName
               };
-              requestUrl = `/${serviceName}${requestUrl}`;
             }
           });
         }
@@ -200,13 +198,19 @@ class ServiceRouter {
           * Route non POST and PUT message types.
           */
 
-          // if request isn't a JSON request the locate an service instance and passthrough the request in plain HTTP
+          // if request isn't a JSON request then locate an service instance and passthrough the request in plain HTTP
           if (request.headers['content-type'] !== 'application/json') {
             hydra.getServicePresence(matchResult.serviceName)
               .then((presenceInfo) => {
                 if (presenceInfo.length > 0) {
                   let idx = Math.floor(Math.random() * presenceInfo.length);
                   let presence = presenceInfo[idx];
+
+                  let segs = requestUrl.split('/');
+                  if (segs[1] === matchResult.serviceName) {
+                    requestUrl = '';
+                  }
+
                   let url = `http://${presence.ip}:${presence.port}${requestUrl}`;
                   serverRequest
                     .get(url)


### PR DESCRIPTION
Improvement to not force services to host websites in a subfolder which is named the same as the service. This means you don't have to do anything special to host your expressjs website.
