### PR TITLE
allow for header and query string auth

### DIFF
--- a/lib/servicerouter.js
+++ b/lib/servicerouter.js
@@ -410,6 +410,7 @@ class ServiceRouter {
       }).toJSON());
     };
 
+
     let msg = Utils.safeJSONParse(message);
     if (!msg) {
       invalidMessage(message);
@@ -417,14 +418,18 @@ class ServiceRouter {
       return;
     }
 
-    msg.body.authResponse = ws.authResponse;
-
     // convert msg JSON object to an actual UMF (class) object
     msg = UMFMessage.createMessage(msg);
+
     if (!msg.to || !msg.from || !msg.body) {
       invalidMessage(msg);
       this.wsDisconnect(ws);
       return;
+    }
+
+    // append authResponse from the ws if relevant
+    if (ws.authResponse) {
+      msg.body.authResponse = ws.authResponse;
     }
 
     let toRoute = UMFMessage.parseRoute(msg.to);


### PR DESCRIPTION
In order to allow ws auth in a browser and from a backend app, this PR allows a client to pass auth with a header or with a query param. Hydra expects one of the two, and forwards it along to the auth service (separate) for validation.

Additionally, this PR improves where and how the `authResponse` is attached to the UMF `body` of outbound messages.