### PR TITLE
Ensure process termination on cleanup

### DIFF
--- a/hydra-router.js
+++ b/hydra-router.js
@@ -14,11 +14,14 @@ const serviceRouter = require('./lib/servicerouter');
  */
 let setupExitHandlers = () => {
   process.on('cleanup', async() => {
-    await serviceRouter.shutdown();
-    await hydra.shutdown();
+    try {
+      await serviceRouter.shutdown();
+      await hydra.shutdown();
+    } catch (error) {
+      console.log(error);
+    }
     process.exit(1);
   });
-
   process.on('SIGTERM', () => {
     hydra.log('fatal', 'Received SIGTERM');
     process.emit('cleanup');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-router",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "description": "A service which routes requests to hydra-based microservices",
   "author": {
     "name": "Carlos Justiniano",


### PR DESCRIPTION
When Redis is down an error happens and `cleanup` signal is trying to update things in Redis, which throws.
As a result, the unhandled exception is caught by handler that will attempt an `cleanup` again with same results, endless loop, maybe... so I wrapped the `cleanup` handler in `try/catch` block so that the process is effectively terminated and it can be collected by the container and restarted.